### PR TITLE
Use mkdir -p to prevent Just recipe error

### DIFF
--- a/justfile
+++ b/justfile
@@ -53,7 +53,7 @@ install-api-geocode-data: install-api-geocode-indexer
 	cd source/api/geocode && \
 		curl -L {{geocode_data_planet}} > planet.tsv.gz && \
 		gzip -d planet.tsv.gz && \
-		mkdir index && \
+		mkdir -p index && \
 		./indexer/target/release/atlasr-api-geocode-indexer --source-file planet.tsv --index-directory index
 
 # Install the indexer for the geocode API.


### PR DESCRIPTION
The `install-api-geocode-data` Just recipe attempts to create a directory at `source/api/geocode/index` on line 56. Since the `source/api/geocode/index` directory already exists in this repository, that command fails.

Using `mkdir -p` doesn't fail if the directory already exists, and fixes this issue.