### PR TITLE
Fix indexing issues: Specify that importance field is optional

### DIFF
--- a/source/api/geocode/indexer/src/main.rs
+++ b/source/api/geocode/indexer/src/main.rs
@@ -37,7 +37,7 @@ struct Record {
     #[serde(rename = "lat")]
     latitude: Option<f64>,
     place_rank: Option<u64>,
-    importance: f64,
+    importance: Option<f64>,
     street: Option<String>,
     city: Option<String>,
     county: Option<String>,


### PR DESCRIPTION
This is a fix for: https://github.com/atlasr-org/atlasr/issues/4

Before this change, records in `planet.tsv` which did not have a important caused indexing to fail.
With this change, they will still be indexed.